### PR TITLE
feature/ignore-cache

### DIFF
--- a/src/Http/Middleware/CacheResponse.php
+++ b/src/Http/Middleware/CacheResponse.php
@@ -12,6 +12,14 @@ class CacheResponse
 {
     public function handle(Request $request, Closure $next, ...$args): Response
     {
+        if ($request->getMethod() !== 'GET') {
+            return $next($request);
+        }
+
+        if (! empty($request->session()->all())) {
+            return $next($request);
+        }
+
         $cacheEnabled = config('content-markdown.cache.enabled', true);
         $cacheKey = $this->getCacheKey($request);
 


### PR DESCRIPTION
Ensure the cache is ignored if the request is not a GET method. This will ensure that we don't attempt to cache PATCH, POST, DELETE requests.

Session can be used to customise the page therefore we will ignore cache if the session is not empty.
